### PR TITLE
Add cache-dependency-path for pnpm in workflow

### DIFF
--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: frontend/clockko-wellness-app/pnpm-lock.yaml
 
       - name: Install deps
         working-directory: frontend/clockko-wellness-app


### PR DESCRIPTION
This fixes the error causing the frontend pipeline to fail.